### PR TITLE
Adding support to options to the transport. 

### DIFF
--- a/lib/backbone.datasource.js
+++ b/lib/backbone.datasource.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 // Kendo UI: kendo.backbone.DataSource
 // -----------------------------------
 //
-// An adapter that wraps around a 
+// An adapter that wraps around a
 // `Backbone.Collection` as the underlying data store and
 // transport for a `kendo.data.DataSource`. This will provide basic
 // data-binding functionality for Kendo UI widgets and controls, such
@@ -18,18 +18,23 @@ var BackboneCollectionAdapter = require('./collectionadapter');
 var BackboneTransport = require('./backbonetransport');
 
 // Setup default schema, if none is provided
-function setupDefaultSchema(target, collection){
-  // build the schema.model, one step at a time, 
+function setupDefaultSchema(target, collection) {
+  // build the schema.model, one step at a time,
   // to ensure it is not replaced, and ensure it is
   // properly set up in case parts of a schema or model
   // are provided by the specific application needs
-  _.defaults(target, { schema: {} });
-  _.defaults(target.schema, { model: {} });
+  _.defaults(target, {
+    schema: {}
+  });
+  _.defaults(target.schema, {
+    model: {}
+  });
 
   // set an id field based on the collection's model.idAttribute,
   // or use the default "id" if none found
   _.defaults(target.schema.model, {
-    id: Object.getPrototypeOf(collection).model.prototype.idAttribute || "id"
+    id: Object.getPrototypeOf(collection).model.prototype.idAttribute ||
+      "id"
   });
 
   return target;
@@ -44,13 +49,15 @@ var DataSource = kendo.data.DataSource.extend({
     var colWrap = new BackboneCollectionAdapter(collection, this);
 
     // configure the Backbone transport with the collection
-    var bbtrans = new BackboneTransport(colWrap);
-    _.defaults(options, { transport: bbtrans });
+    var bbtrans = new BackboneTransport(_.extend({
+      colWrap: colWrap
+    }, options.transport));
+    options.transport = bbtrans;
 
     // initialize the datasource with the new configuration
     options = setupDefaultSchema(options, collection);
     kendo.data.DataSource.prototype.init.call(this, options);
   }
-}); 
+});
 
 module.exports = DataSource;

--- a/lib/backbonetransport.js
+++ b/lib/backbonetransport.js
@@ -11,33 +11,43 @@
 var _ = require('lodash');
 
 // Constructor Function
-function Transport(colWrap){
-  this.colWrap = colWrap;
+function Transport(options) {
+  _.extend(this, options);
 }
 
-// Instance methods. 
+// Instance methods.
 // add basic CRUD operations to the transport
 _.extend(Transport.prototype, {
 
   create: function(options) {
+    if (this.parameterMap) {
+      options.data = this.parameterMap(options.data, 'create');
+    }
     var data = options.data;
 
+
     // create the model in the collection
-    this.colWrap.create(data, function(model){
+    this.colWrap.create(data, function(model) {
       // tell the DataSource we're done
       options.success(model);
     });
   },
 
   read: function(options) {
+    if (this.parameterMap) {
+      options.data = this.parameterMap(options.data, 'read');
+    }
     return this.colWrap.collection.fetch(_.defaults({
-      success: function (collection) {
+      success: function(collection) {
         options.success(collection.toJSON());
       }
     }, options));
   },
 
   update: function(options) {
+    if (this.parameterMap) {
+      options.data = this.parameterMap(options.data, 'update');
+    }
     // find the model
     var model = this.colWrap.collection.get(options.data.id);
 
@@ -49,6 +59,9 @@ _.extend(Transport.prototype, {
   },
 
   destroy: function(options) {
+    if (this.parameterMap) {
+      options.data = this.parameterMap(options.data, 'destroy');
+    }
     // find the model
     var model = this.colWrap.collection.get(options.data.id);
 

--- a/test.js
+++ b/test.js
@@ -52,7 +52,7 @@ describe('kendo-backbone', function () {
   });
 
   describe('sanity', function () {
-  
+
     before(function (done) {
       this.timeout(10000);
       env = jsdom.env({


### PR DESCRIPTION
The datasource always sets a BackboneTransport in the datasource. 
Transport options can be extended from the datasource options. 
Added support to the parameterMap function.

Now the Transport receives an options object instead of only colwrap. That way we can configure it further more
